### PR TITLE
feat: add windows testing capabilities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ parameters:
 
 jobs:
   integration-test:
-    executor: release-management/default
+    executor: release-management/linux
     steps:
       - checkout
       - release-management/install-sfdx-trust

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,9 +6,9 @@
 version: "2.1"
 description: "Orb for releasing npm packages"
 orbs:
-  aws-cli: circleci/aws-cli@1.2.1
-  jq: circleci/jq@2.2.0
-  sfchangecase: salesforce/change-case-management@3.2.0
+  aws-cli: circleci/aws-cli@1.2
+  jq: circleci/jq@2.2
+  sfchangecase: salesforce/change-case-management@3.2
 
 display:
   home_url: "https://circleci.com/orbs/registry/orb/salesforce/npm-release-management"

--- a/src/commands/install-node.yml
+++ b/src/commands/install-node.yml
@@ -1,0 +1,48 @@
+# Copyright (c) 2018, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+
+# How to author commands: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
+description: >
+  Install node version first
+
+parameters:
+  version:
+    description: version of node to install and use
+    default: latest
+    type: string
+  os:
+    description: operating system you want to install node on
+    type: enum
+    enum: ['linux', 'windows']
+    default: 'linux'
+
+steps:
+  - when:
+      condition:
+        equal: ['linux', <<parameters.os>>]
+      steps:
+        - run:
+            name: Install and use node version
+            command: |
+              if [[ "<<parameters.version>>" == "latest" ]]; then
+                nvm install node
+              else
+                nvm install <<parameters.version>>
+              fi
+              echo "Using node: $(node --version)"
+
+  - when:
+      condition:
+        equal: ['windows', <<parameters.os>>]
+      steps:
+        - run:
+            name: Install and use node version
+            command: |
+              if("<<parameters.version>>" -eq "latest") {
+                choco install nodejs
+              } else {
+                choco install nodejs --version <<parameters.version>> --allow-downgrade
+              }
+              echo "Using node: $(node --version)"

--- a/src/commands/install-node.yml
+++ b/src/commands/install-node.yml
@@ -43,6 +43,8 @@ steps:
               if("<<parameters.version>>" -eq "latest") {
                 choco install nodejs
               } else {
-                choco install nodejs --version <<parameters.version>> --allow-downgrade
+                $r = Invoke-WebRequest https://nodejs.org/download/release/index.json | ConvertFrom-Json
+                $latest_of_version = ($r | where { $_.version -like "v<<parameters.version>>*" })[0].version.substring(1)
+                choco install nodejs --version $latest_of_version --allow-downgrade
               }
               echo "Using node: $(node --version)"

--- a/src/examples/test-and-release-package-with-merge.yml
+++ b/src/examples/test-and-release-package-with-merge.yml
@@ -24,6 +24,11 @@ usage:
             upload-coverage: true
         - release-management/test-package:
             name: node-12
+            node_version: '12.16.3'
+        - release-management/test-package:
+            name: win-node-12
+            node_version: '12.16.3'
+            os: windows
         - release-management/release-package:
             post-job-steps:
               - release-management/merge:

--- a/src/examples/test-and-release-package-with-merge.yml
+++ b/src/examples/test-and-release-package-with-merge.yml
@@ -24,10 +24,10 @@ usage:
             upload-coverage: true
         - release-management/test-package:
             name: node-12
-            node_version: '12.16.3'
+            node_version: '12'
         - release-management/test-package:
             name: win-node-12
-            node_version: '12.16.3'
+            node_version: '12'
             os: windows
         - release-management/release-package:
             post-job-steps:

--- a/src/examples/test-and-release-package.yml
+++ b/src/examples/test-and-release-package.yml
@@ -24,10 +24,10 @@ usage:
             upload-coverage: true
         - release-management/test-package:
             name: node-12
-            node_version: '12.16.3'
+            node_version: '12'
         - release-management/test-package:
             name: win-node-12
-            node_version: '12.16.3'
+            node_version: '12'
             os: windows
         - release-management/release-package:
             requires:

--- a/src/examples/test-and-release-package.yml
+++ b/src/examples/test-and-release-package.yml
@@ -24,6 +24,11 @@ usage:
             upload-coverage: true
         - release-management/test-package:
             name: node-12
+            node_version: '12.16.3'
+        - release-management/test-package:
+            name: win-node-12
+            node_version: '12.16.3'
+            os: windows
         - release-management/release-package:
             requires:
               - node-latest

--- a/src/examples/test-and-release-signed-plugin.yml
+++ b/src/examples/test-and-release-signed-plugin.yml
@@ -24,6 +24,11 @@ usage:
             upload-coverage: true
         - release-management/test-package:
             name: node-12
+            node_version: '12.16.3'
+        - release-management/test-package:
+            name: win-node-12
+            node_version: '12.16.3'
+            os: windows
         - release-management/release-package:
             sign: true
             requires:

--- a/src/examples/test-and-release-signed-plugin.yml
+++ b/src/examples/test-and-release-signed-plugin.yml
@@ -24,10 +24,10 @@ usage:
             upload-coverage: true
         - release-management/test-package:
             name: node-12
-            node_version: '12.16.3'
+            node_version: '12'
         - release-management/test-package:
             name: win-node-12
-            node_version: '12.16.3'
+            node_version: '12'
             os: windows
         - release-management/release-package:
             sign: true

--- a/src/executors/linux.yml
+++ b/src/executors/linux.yml
@@ -4,6 +4,8 @@
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 
 # How to author Executors: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors
+# https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
+
 description: >
   Linux os
 

--- a/src/executors/linux.yml
+++ b/src/executors/linux.yml
@@ -5,10 +5,7 @@
 
 # How to author Executors: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors
 description: >
-  Default node executor
-docker:
-  - image: node:<<parameters.tag>>
-parameters:
-  tag:
-    default: "12"
-    type: string
+  Linux os
+
+machine: # executor type
+  image: ubuntu-2004:202010-01 # # recommended linux image - includes Ubuntu 20.04, docker 19.03.13, docker-compose 1.27.4

--- a/src/executors/windows.yml
+++ b/src/executors/windows.yml
@@ -1,0 +1,36 @@
+# Copyright (c) 2018, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+
+# How to author Executors: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors
+
+# Extracted from https://circleci.com/developer/orbs/orb/circleci/windows
+
+description: >
+  An executor preloaded with Visual Studio 2019 plus a number of other
+  development tools.
+parameters:
+  version:
+    type: string
+    description: The image version to use when executing. Defaults to "stable".
+    default: stable
+  shell:
+    type: string
+    description: |
+      The shell to use. Defaults to `powershell.exe`
+    default: powershell.exe
+  size:
+    type: enum
+    description: |
+      The size of Windows resource to use. Defaults to medium.
+    default: medium
+    enum:
+      - medium
+      - large
+      - xlarge
+      - 2xlarge
+machine:
+  image: 'windows-server-2019-vs2019:<< parameters.version >>'
+  resource_class: windows.<< parameters.size >>
+  shell: << parameters.shell >>

--- a/src/jobs/release-lerna-packages.yml
+++ b/src/jobs/release-lerna-packages.yml
@@ -36,7 +36,7 @@ parameters:
     type: boolean
     default: false
 
-executor: default
+executor: linux
 
 steps:
   - checkout

--- a/src/jobs/release-package.yml
+++ b/src/jobs/release-package.yml
@@ -40,7 +40,7 @@ parameters:
     type: boolean
     default: false
 
-executor: default
+executor: linux
 
 steps:
   - checkout

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -10,7 +10,7 @@ parameters:
   node_version:
     description: version of node to run tests against
     type: string
-    default: latest
+    default: "12"
   upload-coverage:
     description: if true, the job will submit code coverage report to codecov.io
     default: false

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -15,30 +15,51 @@ parameters:
     description: if true, the job will submit code coverage report to codecov.io
     default: false
     type: boolean
+  os:
+    description: operating system you want to test against
+    type: enum
+    enum: ['linux', 'windows']
+    default: 'linux'
 
 executor:
-  name: default
-  tag: << parameters.node_version >>
+  name: << parameters.os >>
 
 steps:
+  - install-node:
+      version: <<parameters.node_version>>
+      os: <<parameters.os>>
   - checkout
-  - restore_cache:
-      keys:
-        - v1-npm-{{checksum ".circleci/config.yml"}}-{{checksum "yarn.lock"}}
-        - v1-npm-{{checksum ".circleci/config.yml"}}
-  - run:
-      name: Install dependencies
-      command: yarn
-  - run:
-      name: Build
-      command: yarn build
-  - save_cache:
-      key: v1-npm-{{checksum ".circleci/config.yml"}}-{{checksum "yarn.lock"}}
-      paths:
-        - ~/node_modules
-        - /usr/local/share/.cache/yarn
-        - /usr/local/share/.config/yarn
-  - verify-installed-plugin
+  - when:
+      condition:
+        equal: ['windows', <<parameters.os>>]
+      steps:
+        - run:
+            name: Install dependencies
+            command: yarn
+        - run:
+            name: Build
+            command: yarn build
+  - when:
+      condition:
+        equal: ['linux', <<parameters.os>>]
+      steps:
+        - restore_cache:
+            keys:
+              - v1-npm-{{checksum ".circleci/config.yml"}}-{{checksum "yarn.lock"}}
+              - v1-npm-{{checksum ".circleci/config.yml"}}
+        - run:
+            name: Install dependencies
+            command: yarn
+        - run:
+            name: Build
+            command: yarn build
+        - save_cache:
+            key: v1-npm-{{checksum ".circleci/config.yml"}}-{{checksum "yarn.lock"}}
+            paths:
+              - ~/node_modules
+              - /usr/local/share/.cache/yarn
+              - /usr/local/share/.config/yarn
+        - verify-installed-plugin
   - run:
       name: Testing
       command: yarn test

--- a/src/jobs/test-ts-update.yml
+++ b/src/jobs/test-ts-update.yml
@@ -21,10 +21,11 @@ parameters:
     default: ESNext
 
 executor:
-  name: default
-  tag: <<parameters.node_version>>
+  name: linux
 
 steps:
+  - install-node:
+      version: <<parameters.node_version>>
   - checkout
   - install-sf-release
   - run:

--- a/src/jobs/validate-pr.yml
+++ b/src/jobs/validate-pr.yml
@@ -6,7 +6,7 @@
 description: >
   Validate that PR contains reference to work item id or a reference to a github issue. Job will be skipped if [skip-validate-pr] is found in the commit message
 
-executor: default
+executor: linux
 
 steps:
   - run:


### PR DESCRIPTION
Adds
- separate executors for linux and windows
- `install-node` command to install specific versions of node. Works with both linux and windows
- adds `os` parameter to `test-package` job

@W-8623693@