### PR TITLE
[semver:minor] allow lts and lts-maintenance nvm installs

### DIFF
--- a/src/commands/install-node.yml
+++ b/src/commands/install-node.yml
@@ -31,6 +31,12 @@ steps:
               if [[ "<<parameters.version>>" == "latest" ]]; then
                 nvm install node
                 nvm alias default node
+              elif [[ "<<parameters.version>>" ==  "lts" ]]; then
+                nvm install $(nvm_alias lts/*)
+                nvm alias default $(nvm_alias lts/*)
+              elif [[ "<<parameters.version>>" == "lts-maintenance" ]]; then
+                nvm install $(nvm-alias lts/-1)
+                nvm alias default $(nvm_alias lts/-1)
               else
                 nvm install <<parameters.version>>
                 nvm alias default <<parameters.version>>


### PR DESCRIPTION
### What does this PR do?
Allows a user of this orb to specify `lts` or `lts-maintenance` node versions

~This won't work correctly until after https://github.com/nvm-sh/nvm/commit/4da7f101a2d00521eba5fa69a4bd9394bf5c817b is released so the PR's leif creates when https://github.com/salesforcecli/leif/pull/23 is merged should only be merged after that.~
https://github.com/nvm-sh/nvm/releases/tag/v0.38.0 has been released :tada: