### PR TITLE
@W-9091292@ disable codecov uploads for windows

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,6 +9,7 @@ orbs:
   aws-cli: circleci/aws-cli@1.2
   jq: circleci/jq@2.2
   sfchangecase: salesforce/change-case-management@3.2
+  codecov: codecov/codecov@1.1.3
 
 display:
   home_url: "https://circleci.com/orbs/registry/orb/salesforce/npm-release-management"

--- a/src/commands/upload-coverage.yml
+++ b/src/commands/upload-coverage.yml
@@ -9,4 +9,4 @@ description: >
 
 steps:
   - run: ./node_modules/.bin/nyc report --reporter text-lcov > coverage.lcov
-  - codecov/upload:
+  - codecov/upload

--- a/src/commands/upload-coverage.yml
+++ b/src/commands/upload-coverage.yml
@@ -9,4 +9,4 @@ description: >
 
 steps:
   - run: ./node_modules/.bin/nyc report --reporter text-lcov > coverage.lcov
-  - run: curl -s https://codecov.io/bash | bash
+  - codecov/upload:

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -86,6 +86,6 @@ steps:
         and:
           - equal: ['linux', <<parameters.os>>]
           - and:
-            - equal: <<parameters.upload-coverage>>        
+              - equal: <<parameters.upload-coverage>>
       steps:
         - upload-coverage

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -82,7 +82,7 @@ steps:
         echo "Using node: $(node --version)"
         yarn test
   - when:
-      condition: 
+      condition:
         equal: <<parameters.upload-coverage>>
         and:
           not:

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -86,6 +86,6 @@ steps:
         and:
           - equal: ['linux', <<parameters.os>>]
           - and:
-            <<parameters.upload-coverage>>
+              - equal: [true, <<parameters.upload-coverage>>]
       steps:
         - upload-coverage

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -85,6 +85,7 @@ steps:
       condition:
         and:
           - equal: ['linux', <<parameters.os>>]
-          - and: <<parameters.upload-coverage>>
+          - and:
+            <<parameters.upload-coverage>>
       steps:
         - upload-coverage

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -82,6 +82,9 @@ steps:
         echo "Using node: $(node --version)"
         yarn test
   - when:
-      condition: <<parameters.upload-coverage>>
+      condition:
+        and: <<parameters.upload-coverage>>
+        not:
+          equal: [windows, <<parameters.os>>]
       steps:
         - upload-coverage

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -82,9 +82,9 @@ steps:
         echo "Using node: $(node --version)"
         yarn test
   - when:
-      condition:
-        and: <<parameters.upload-coverage>>
-        not:
-          equal: [windows, <<parameters.os>>]
+      condition: <<parameters.upload-coverage>>
+        and:
+          - not:
+            - equal: [windows, <<parameters.os>>]
       steps:
         - upload-coverage

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -84,7 +84,7 @@ steps:
   - when:
       condition: <<parameters.upload-coverage>>
         and:
-          - not:
-            - equal: [windows, <<parameters.os>>]
+          not:
+            equal: [windows, <<parameters.os>>]
       steps:
         - upload-coverage

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -83,9 +83,9 @@ steps:
         yarn test
   - when:
       condition:
-        equal: <<parameters.upload-coverage>>
         and:
-          not:
-            equal: [windows, <<parameters.os>>]
+          - equal: ['linux', <<parameters.os>>]
+          - and:
+            - equal: <<parameters.upload-coverage>>        
       steps:
         - upload-coverage

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -85,7 +85,6 @@ steps:
       condition:
         and:
           - equal: ['linux', <<parameters.os>>]
-          - and:
-              - equal: [true, <<parameters.upload-coverage>>]
+          - equal: [true, <<parameters.upload-coverage>>]
       steps:
         - upload-coverage

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -85,7 +85,6 @@ steps:
       condition:
         and:
           - equal: ['linux', <<parameters.os>>]
-          - and:
-              - equal: <<parameters.upload-coverage>>
+          - and: <<parameters.upload-coverage>>
       steps:
         - upload-coverage

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -82,7 +82,8 @@ steps:
         echo "Using node: $(node --version)"
         yarn test
   - when:
-      condition: <<parameters.upload-coverage>>
+      condition: 
+        equal: <<parameters.upload-coverage>>
         and:
           not:
             equal: [windows, <<parameters.os>>]


### PR DESCRIPTION
Upload coverage on windows is failing right now due working means of uploading coverage via codecov orb. Disabling unitl suitable means found.