### PR TITLE
fix: bump cache version to v5

### DIFF
--- a/src/jobs/release-lerna-packages.yml
+++ b/src/jobs/release-lerna-packages.yml
@@ -46,9 +46,9 @@ steps:
   - configure-github
   - restore_cache:
       keys:
-        - v3-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
-        - v3-npm-{{ .Branch }}
-        - v3-npm
+        - v5-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
+        - v5-npm-{{ .Branch }}
+        - v5-npm
   - run:
       name: Install dependencies
       command: yarn
@@ -56,21 +56,21 @@ steps:
       name: Build
       command: yarn build
   - save_cache:
-      key: v3-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
+      key: v5-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
       paths:
         - node_modules
         - ~/node_modules
         - ~/.cache/yarn
         - ~/.config/yarn
   - save_cache:
-      key: v3-npm-{{ .Branch }}
+      key: v5-npm-{{ .Branch }}
       paths:
         - node_modules
         - ~/node_modules
         - ~/.cache/yarn
         - ~/.config/yarn
   - save_cache:
-      key: v3-npm
+      key: v5-npm
       paths:
         - node_modules
         - ~/node_modules
@@ -80,7 +80,7 @@ steps:
   # - if environment looks like it is prepped to do change cases, and we're on "latest" tag
   - when:
       condition:
-          equal: ['latest', <<parameters.tag>>]
+        equal: ["latest", <<parameters.tag>>]
       steps:
         - install-change-case-mgmt
         - change-case-create
@@ -150,7 +150,7 @@ steps:
   # clean up the CTC cases
   - when:
       condition:
-        equal: ['latest', <<parameters.tag>>]
+        equal: ["latest", <<parameters.tag>>]
       steps:
         - run:
             when: on_fail

--- a/src/jobs/release-package.yml
+++ b/src/jobs/release-package.yml
@@ -66,9 +66,9 @@ steps:
   - configure-github
   - restore_cache:
       keys:
-        - v3-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
-        - v3-npm-{{ .Branch }}
-        - v3-npm
+        - v5-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
+        - v5-npm-{{ .Branch }}
+        - v5-npm
 
   - steps: <<parameters.pre-job-steps>>
 
@@ -79,21 +79,21 @@ steps:
       name: Build
       command: yarn build
   - save_cache:
-      key: v3-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
+      key: v5-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
       paths:
         - node_modules
         - ~/node_modules
         - ~/.cache/yarn
         - ~/.config/yarn
   - save_cache:
-      key: v3-npm-{{ .Branch }}
+      key: v5-npm-{{ .Branch }}
       paths:
         - node_modules
         - ~/node_modules
         - ~/.cache/yarn
         - ~/.config/yarn
   - save_cache:
-      key: v3-npm
+      key: v5-npm
       paths:
         - node_modules
         - ~/node_modules
@@ -103,7 +103,7 @@ steps:
   # - if environment looks like it is prepped to do change cases, and we're on "latest" tag
   - when:
       condition:
-          equal: ['latest', <<parameters.tag>>]
+        equal: ["latest", <<parameters.tag>>]
       steps:
         - install-change-case-mgmt
         - change-case-create
@@ -194,7 +194,7 @@ steps:
   # clean up the CTC cases
   - when:
       condition:
-        equal: ['latest', <<parameters.tag>>]
+        equal: ["latest", <<parameters.tag>>]
       steps:
         - run:
             when: on_fail

--- a/src/jobs/release-package.yml
+++ b/src/jobs/release-package.yml
@@ -51,7 +51,7 @@ parameters:
   node_version:
     description: version of node to use
     type: string
-    default: "12"
+    default: '12'
 
 executor: linux
 
@@ -103,7 +103,7 @@ steps:
   # - if environment looks like it is prepped to do change cases, and we're on "latest" tag
   - when:
       condition:
-        equal: ["latest", <<parameters.tag>>]
+        equal: ['latest', <<parameters.tag>>]
       steps:
         - install-change-case-mgmt
         - change-case-create
@@ -194,7 +194,7 @@ steps:
   # clean up the CTC cases
   - when:
       condition:
-        equal: ["latest", <<parameters.tag>>]
+        equal: ['latest', <<parameters.tag>>]
       steps:
         - run:
             when: on_fail

--- a/src/jobs/test-nut.yml
+++ b/src/jobs/test-nut.yml
@@ -14,23 +14,23 @@ parameters:
   os:
     description: operating system to run tests on
     type: enum
-    enum: ['linux', 'windows']
-    default: 'linux'
+    enum: ["linux", "windows"]
+    default: "linux"
   sfdx_version:
     description: 'By default, the latest version of the standalone CLI will be installed. To install via npm, supply a version tag such as "latest" or "6".'
-    default: ''
+    default: ""
     type: string
   sfdx_executable_path:
     description: "Path to sfdx executable to be used by NUTs, defaults to ''"
-    default: ''
+    default: ""
     type: string
   npm_module_name:
     description: "The fully qualified npm module name, i.e. @salesforce/plugins-data, defaults to ''"
-    default: ''
+    default: ""
     type: string
   repo_tag:
     description: "The tag of the module repo to checkout, '' defaults to branch/PR"
-    default: ''
+    default: ""
     type: string
 
 executor:
@@ -50,7 +50,7 @@ steps:
   - when:
       condition:
         and:
-          - equal: ['windows', <<parameters.os>>]
+          - equal: ["windows", <<parameters.os>>]
           - <<parameters.repo_tag>>
       steps:
         - run:
@@ -64,7 +64,7 @@ steps:
   - when:
       condition:
         and:
-          - equal: ['linux', <<parameters.os>>]
+          - equal: ["linux", <<parameters.os>>]
           - <<parameters.repo_tag>>
       steps:
         - run:
@@ -72,7 +72,7 @@ steps:
             command: git checkout v<<parameters.repo_tag>> || git checkout <<parameters.npm_module_name>>@<<parameters.repo_tag>>
   - when:
       condition:
-        equal: ['windows', <<parameters.os>>]
+        equal: ["windows", <<parameters.os>>]
       steps:
         - run:
             name: Install dependencies
@@ -82,13 +82,13 @@ steps:
             command: yarn build
   - when:
       condition:
-        equal: ['linux', <<parameters.os>>]
+        equal: ["linux", <<parameters.os>>]
       steps:
         - restore_cache:
             keys:
-              - v3-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
-              - v3-npm-{{ .Branch }}
-              - v3-npm
+              - v5-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
+              - v5-npm-{{ .Branch }}
+              - v5-npm
         - run:
             name: Install dependencies
             command: yarn
@@ -96,21 +96,21 @@ steps:
             name: Build
             command: yarn build
         - save_cache:
-            key: v3-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
+            key: v5-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
             paths:
               - node_modules
               - ~/node_modules
               - ~/.cache/yarn
               - ~/.config/yarn
         - save_cache:
-            key: v3-npm-{{ .Branch }}
+            key: v5-npm-{{ .Branch }}
             paths:
               - node_modules
               - ~/node_modules
               - ~/.cache/yarn
               - ~/.config/yarn
         - save_cache:
-            key: v3-npm
+            key: v5-npm
             paths:
               - node_modules
               - ~/node_modules

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -18,8 +18,8 @@ parameters:
   os:
     description: operating system you want to test against
     type: enum
-    enum: ['linux', 'windows']
-    default: 'linux'
+    enum: ["linux", "windows"]
+    default: "linux"
 
 executor:
   name: << parameters.os >>
@@ -31,7 +31,7 @@ steps:
   - checkout
   - when:
       condition:
-        equal: ['windows', <<parameters.os>>]
+        equal: ["windows", <<parameters.os>>]
       steps:
         - run:
             name: Install dependencies
@@ -41,13 +41,13 @@ steps:
             command: yarn build
   - when:
       condition:
-        equal: ['linux', <<parameters.os>>]
+        equal: ["linux", <<parameters.os>>]
       steps:
         - restore_cache:
             keys:
-              - v3-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
-              - v3-npm-{{ .Branch }}
-              - v3-npm
+              - v5-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
+              - v5-npm-{{ .Branch }}
+              - v5-npm
         - run:
             name: Install dependencies
             command: yarn
@@ -55,21 +55,21 @@ steps:
             name: Build
             command: yarn build
         - save_cache:
-            key: v3-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
+            key: v5-npm-{{ .Branch }}-{{checksum "yarn.lock"}}
             paths:
               - node_modules
               - ~/node_modules
               - ~/.cache/yarn
               - ~/.config/yarn
         - save_cache:
-            key: v3-npm-{{ .Branch }}
+            key: v5-npm-{{ .Branch }}
             paths:
               - node_modules
               - ~/node_modules
               - ~/.cache/yarn
               - ~/.config/yarn
         - save_cache:
-            key: v3-npm
+            key: v5-npm
             paths:
               - node_modules
               - ~/node_modules
@@ -84,7 +84,7 @@ steps:
   - when:
       condition:
         and:
-          - equal: ['linux', <<parameters.os>>]
+          - equal: ["linux", <<parameters.os>>]
           - equal: [true, <<parameters.upload-coverage>>]
       steps:
         - upload-coverage


### PR DESCRIPTION
while working the windows cache WI, something wrote windows files to the v3 npm cache, resulting in stuf like this.  https://app.circleci.com/pipelines/github/salesforcecli/plugin-user/564/workflows/abf0583e-0a9d-4c22-8deb-7c4c2b4446c1/jobs/1683

It **should** just affect plugin-user.

This bumps the cache keys to a v5 (I was also using v4 in my attempt at the WI so I'm skipping over that one since some will exist that we don't want).

@W-0@ 