### PR TITLE
check if releasable before installing deps

### DIFF
--- a/src/jobs/release-lerna-packages.yml
+++ b/src/jobs/release-lerna-packages.yml
@@ -40,8 +40,14 @@ executor: linux
 
 steps:
   - checkout
-  - install-sfdx-trust
   - install-sf-release
+    # - run npm:release:validate to see if a release is necessary - will halt workflow if not releasable
+  - when:
+      condition:
+        not: <<parameters.dryrun>>
+      steps:
+        halt-workflow-if-not-releasable
+  - install-sfdx-trust
   - install-standard-version
   - configure-github
   - restore_cache:
@@ -77,12 +83,6 @@ steps:
         - ~/.cache/yarn
         - ~/.config/yarn
 
-  # - run npm:release:validate to see if a release is necessary - will halt workflow if not releasable
-  - when:
-      condition:
-        not: <<parameters.dryrun>>
-      steps:
-        halt-workflow-if-not-releasable
   # - if environment looks like it is prepped to do change cases, and we're on "latest" tag
   - when:
       condition:

--- a/src/jobs/release-package.yml
+++ b/src/jobs/release-package.yml
@@ -60,8 +60,14 @@ steps:
       version: <<parameters.node_version>>
       os: linux
   - checkout
-  - install-sfdx-trust
   - install-sf-release
+    # - run npm:release:validate to see if a release is necessary - will set env var NEEDS_RELEASE
+  - when:
+      condition:
+        not: <<parameters.dryrun>>
+      steps:
+        halt-workflow-if-not-releasable
+  - install-sfdx-trust
   - install-standard-version
   - configure-github
   - restore_cache:
@@ -100,12 +106,6 @@ steps:
         - ~/.cache/yarn
         - ~/.config/yarn
 
-  # - run npm:release:validate to see if a release is necessary - will set env var NEEDS_RELEASE
-  - when:
-      condition:
-        not: <<parameters.dryrun>>
-      steps:
-        halt-workflow-if-not-releasable
   # - if environment looks like it is prepped to do change cases, and we're on "latest" tag
   - when:
       condition:


### PR DESCRIPTION
Run `halt-workflow-if-not-releasable` step before installing the dependencies. By doing this, workflows that are not releasable will halt more quickly