### PR TITLE
Add skip-ci param to dependabot-automerge

### DIFF
--- a/src/jobs/dependabot-automerge.yml
+++ b/src/jobs/dependabot-automerge.yml
@@ -12,6 +12,10 @@ parameters:
     type: enum
     enum: ['patch', 'minor', 'major']
     default: 'minor'
+  skip-ci:
+    description: Optionally skip ci builds on merges into main
+    type: boolean
+    default: false
 
 executor:
   name: linux
@@ -23,6 +27,17 @@ steps:
   - run:
       name: Install dependencies
       command: yarn
-  - run:
-      name: Upgrade one dependency
-      command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>"
+  - when:
+      condition: <<parameters.skip-ci>>
+    steps:
+      - run:
+          name: Upgrade one dependency
+          command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>" --skip-ci
+
+  - when:
+      condition:
+        not: <<parameters.skip-ci>>
+      steps:
+        - run:
+            name: Upgrade one dependency
+            command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>"

--- a/src/jobs/dependabot-automerge.yml
+++ b/src/jobs/dependabot-automerge.yml
@@ -27,12 +27,13 @@ steps:
   - run:
       name: Install dependencies
       command: yarn
+
   - when:
       condition: <<parameters.skip-ci>>
-    steps:
-      - run:
-          name: Upgrade one dependency
-          command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>" --skip-ci
+      steps:
+        - run:
+            name: Upgrade one dependency
+            command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>" --skip-ci
 
   - when:
       condition:


### PR DESCRIPTION
Adds `skip-ci` parameter to the `dependabot-automerge` job so that we can avoid building new releases for specific repos

@W-9910648@