### PR TITLE
[semver:minor] custom nuts

### DIFF
--- a/src/jobs/test-nut.yml
+++ b/src/jobs/test-nut.yml
@@ -42,6 +42,10 @@ parameters:
       - large
       - xlarge
       - 2xlarge
+  command:
+    description: 'Custom command that runs NUTs.  By default, yarn test:nuts'
+    default: 'yarn test:nuts'
+    type: string
 
 executor:
   name: << parameters.os >>
@@ -142,7 +146,7 @@ steps:
         echo "Using node: $(node --version)"
         echo "Environment Variables:"
         env
-        yarn test:nuts
+        << parameters.command >>
       # this is in the command instead of the circle project environment to prevent it from happening on windows
   - store_artifacts:
       path: artifacts


### PR DESCRIPTION
@W-9924355@

Lets you specify NUTs to run (still defaults to yarn test:nuts)

I used this on plugin-source here: 
https://github.com/salesforcecli/plugin-source/pull/245

https://app.circleci.com/pipelines/github/salesforcecli/plugin-source?branch=sm%2Fnuts-in-parallel

Once this merges, that branch should be set to use orb v4, not the orb:sha

