### PR TITLE
[semver:minor] feat: add merge-method param to dependabot-automerge

### DIFF
--- a/src/jobs/dependabot-automerge.yml
+++ b/src/jobs/dependabot-automerge.yml
@@ -16,10 +16,11 @@ parameters:
     description: Optionally skip ci builds on merges into main
     type: boolean
     default: false
-  squash:
-    description: squash the commits into one commit and merge it into the base branch
-    type: boolean
-    default: false
+  merge-method:
+    description: merge method to use
+    type: enum
+    enum: ['merge', 'squash', 'rebase']
+    default: 'merge' 
 
 executor:
   name: linux
@@ -37,7 +38,10 @@ steps:
       steps:
         - run:
             name: Upgrade one dependency
-            command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>" --skip-ci
+            command: |
+              sf-release dependabot:automerge --skip-ci \
+              --max-version-bump "<<parameters.max-version-bump>>" \
+              --merge-method "<<parameters.merge-method>>"
 
   - when:
       condition:
@@ -45,21 +49,8 @@ steps:
       steps:
         - run:
             name: Upgrade one dependency
-            command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>"
+            command: |
+              sf-release dependabot:automerge \
+              --max-version-bump "<<parameters.max-version-bump>>" \
+              --merge-method "<<parameters.merge-method>>"
 
-  - when:
-      condition: <<parameters.squash>>
-      steps:
-        - run:
-            name: Upgrade one dependency
-            command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>" --squash
-
-  - when:
-      condition:
-        and:
-          - <<parameters.skip-ci>>
-          - <<parameters.squash>>
-      steps:
-        - run:
-            name: Upgrade one dependency
-            command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>" --skip-ci --squash

--- a/src/jobs/dependabot-automerge.yml
+++ b/src/jobs/dependabot-automerge.yml
@@ -20,7 +20,7 @@ parameters:
     description: merge method to use
     type: enum
     enum: ['merge', 'squash', 'rebase']
-    default: 'merge' 
+    default: 'merge'
 
 executor:
   name: linux

--- a/src/jobs/dependabot-automerge.yml
+++ b/src/jobs/dependabot-automerge.yml
@@ -16,6 +16,10 @@ parameters:
     description: Optionally skip ci builds on merges into main
     type: boolean
     default: false
+  squash:
+    description: squash the commits into one commit and merge it into the base branch
+    type: boolean
+    default: false
 
 executor:
   name: linux
@@ -42,3 +46,20 @@ steps:
         - run:
             name: Upgrade one dependency
             command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>"
+
+  - when:
+      condition: <<parameters.squash>>
+      steps:
+        - run:
+            name: Upgrade one dependency
+            command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>" --squash
+
+  - when:
+      condition:
+        and:
+          - <<parameters.skip-ci>>
+          - <<parameters.squash>>
+      steps:
+        - run:
+            name: Upgrade one dependency
+            command: sf-release dependabot:automerge --max-version-bump "<<parameters.max-version-bump>>" --skip-ci --squash


### PR DESCRIPTION
Adds `merge-method` parameter to the dependabot-automerge job so that PRs can be merged in repos with `merge commit` option disabled.

**Depends on**: https://github.com/salesforcecli/plugin-release-management/pull/404

@W-0@