### PR TITLE
[semver:minor] (windows) pin node lts to v16.13.2 and latest to v17.3.1

### DIFF
--- a/src/commands/install-node.yml
+++ b/src/commands/install-node.yml
@@ -58,26 +58,30 @@ steps:
       steps:
         - run:
             name: Install and use node version
-            # this was the code for "latest".  it's temporarily redirected to use LTS due to an npm cli bug
-            #           $latest = $registry | jq -c -r '.[0].version | ltrimstr(\"v\")'
-
-            #                nvm install $latest
-            #                nvm use $latest
             command: |
               $nodeIndex = "https://nodejs.org/download/release/index.json"
               $registry = (Invoke-WebRequest $nodeIndex).content
 
               if ("<<parameters.version>>" -eq "latest") {
-                $latest = $registry | jq -c -r '.[0].version | ltrimstr(\"v\")'
+                # $latest = $registry | jq -c -r '.[0].version | ltrimstr(\"v\")'
 
-                nvm install $latest
-                nvm use $latest
+                # nvm install $latest
+                # nvm use $latest
+                #
+                # Installing previous LTS v16.13.2 due to an npm cli bug
+                echo "Installing previous LTS v16.13.2 due to an npm cli bug"
+                nvm install 16.13.2
+                nvm use 16.13.2
               } elseif ("<<parameters.version>>" -eq "lts") {
-                $lts = $registry |
-                    jq -c -r 'first(.[] | select(.lts != false)).version | ltrimstr(\"v\")'
+                # $lts = $registry |
+                #     jq -c -r 'first(.[] | select(.lts != false)).version | ltrimstr(\"v\")'
 
-                nvm install $lts
-                nvm use $lts
+                # nvm install $lts
+                #
+                # Installing previous LTS v16.13.2 due to an npm cli bug
+                echo "Installing previous LTS v16.13.2 due to an npm cli bug"
+                nvm install 16.13.2
+                nvm use 16.13.2
               } elseif ("<<parameters.version>>" -eq "maintenance") {
                 $active = $registry | jq -c -r 'first(.[] | select(.lts != false)).lts'
                 $maintenance = $registry |

--- a/src/commands/install-node.yml
+++ b/src/commands/install-node.yml
@@ -68,11 +68,10 @@ steps:
               $registry = (Invoke-WebRequest $nodeIndex).content
 
               if ("<<parameters.version>>" -eq "latest") {
-                $lts = $registry |
-                    jq -c -r 'first(.[] | select(.lts != false)).version | ltrimstr(\"v\")'
+                $latest = $registry | jq -c -r '.[0].version | ltrimstr(\"v\")'
 
-                nvm install $lts
-                nvm use $lts
+                nvm install $latest
+                nvm use $latest
               } elseif ("<<parameters.version>>" -eq "lts") {
                 $lts = $registry |
                     jq -c -r 'first(.[] | select(.lts != false)).version | ltrimstr(\"v\")'

--- a/src/commands/install-node.yml
+++ b/src/commands/install-node.yml
@@ -68,10 +68,10 @@ steps:
                 # nvm install $latest
                 # nvm use $latest
                 #
-                # Installing previous LTS v16.13.2 due to an npm cli bug
-                echo "Installing previous LTS v16.13.2 due to an npm cli bug"
-                nvm install 16.13.2
-                nvm use 16.13.2
+                # Installing previous LTS v17.3.1 due to an npm cli bug
+                echo "Installing previous LTS v17.3.1 due to an npm cli bug"
+                nvm install 17.3.1
+                nvm use 17.3.1
               } elseif ("<<parameters.version>>" -eq "lts") {
                 # $lts = $registry |
                 #     jq -c -r 'first(.[] | select(.lts != false)).version | ltrimstr(\"v\")'


### PR DESCRIPTION
Pin node in windows install node script to v16.13.2 for `lts` and `latest` tags.

Current `lts` and `latest` includes npm v8.3.1 which always fails on windows.

QA:
See https://github.com/salesforcecli/plugin-org/pull/289