### PR TITLE
fix: add node install to run command keyword [semver patch]

### DIFF
--- a/src/jobs/run-command-keyword.yml
+++ b/src/jobs/run-command-keyword.yml
@@ -21,8 +21,8 @@ parameters:
 
 steps:
   - install-node:
-    version: <<parameters.node_version>>
-    os: linux
+      version: <<parameters.node_version>>
+      os: linux
   - checkout
   - run:
       name: Determine Sandbox NUTs

--- a/src/jobs/run-command-keyword.yml
+++ b/src/jobs/run-command-keyword.yml
@@ -4,6 +4,10 @@ description: >
 executor: linux
 
 parameters:
+  node_version:
+    description: version of node to run tests against
+    type: string
+    default: 'latest'
   timeout:
     description: timeout of the CircleCI job
     type: string
@@ -16,6 +20,9 @@ parameters:
     type: string
 
 steps:
+  - install-node:
+    version: <<parameters.node_version>>
+    os: linux
   - checkout
   - run:
       name: Determine Sandbox NUTs


### PR DESCRIPTION
Install of sfdx-cli was failing in run-command-keyword job due to a min required node version from node-fetch library. Added node install step to solve this issue.