### PR TITLE
feat: skip cache for test builds

### DIFF
--- a/src/jobs/test-nut.yml
+++ b/src/jobs/test-nut.yml
@@ -46,6 +46,10 @@ parameters:
     description: 'Custom command that runs NUTs.  By default, yarn test:nuts'
     default: 'yarn test:nuts'
     type: string
+  use-cache:
+    description: 'Do not load or save cache'
+    type: boolean
+    default: true
 
 executor:
   name: << parameters.os >>
@@ -87,7 +91,9 @@ steps:
             command: git checkout v<<parameters.repo_tag>> || git checkout <<parameters.npm_module_name>>@<<parameters.repo_tag>>
   - when:
       condition:
-        equal: ['windows', <<parameters.os>>]
+        or:
+          - equal: ['windows', <<parameters.os>>]
+          - equal: [false, <<parameters.use-cache>>]
       steps:
         - run:
             name: Install dependencies
@@ -97,7 +103,9 @@ steps:
             command: yarn build
   - when:
       condition:
-        equal: ['linux', <<parameters.os>>]
+        and:
+          - equal: ['linux', <<parameters.os>>]
+          - equal: [true, <<parameters.use-cache>>]
       steps:
         - restore_cache:
             keys:

--- a/src/jobs/test-package.yml
+++ b/src/jobs/test-package.yml
@@ -24,6 +24,10 @@ parameters:
     description: command that will execute tests
     type: string
     default: 'yarn test'
+  use-cache:
+    description: 'Do not load or save cache'
+    type: boolean
+    default: true
 
 executor:
   name: << parameters.os >>
@@ -35,7 +39,9 @@ steps:
   - checkout
   - when:
       condition:
-        equal: ['windows', <<parameters.os>>]
+        or:
+          - equal: ['windows', <<parameters.os>>]
+          - equal: [false, <<parameters.use-cache>>]
       steps:
         - run:
             name: Install dependencies
@@ -45,7 +51,8 @@ steps:
             command: yarn build
   - when:
       condition:
-        equal: ['linux', <<parameters.os>>]
+        and:
+          - equal: ['linux', <<parameters.os>>]
       steps:
         - restore_cache:
             keys:


### PR DESCRIPTION
use-cache (default true) for UT/NUTs

makes it easier to see if CI cache is causing failures

Proof of correctness
this commit https://github.com/salesforcecli/plugin-env/pull/252/commits/fc7d2702d00a402d1561520e328caabd4be28752
produced this correct run https://app.circleci.com/pipelines/github/salesforcecli/plugin-env?branch=sm%2Fenv-create-scratch&filter=all
