### PR TITLE
chore: pin sf-release to v2

### DIFF
--- a/src/commands/install-sf-release.yml
+++ b/src/commands/install-sf-release.yml
@@ -9,7 +9,7 @@ description: >
 parameters:
   version:
     description: By default, the latest version of @salesforce/plugin-release-management (sf-release) will be installed.  You can supply an npm tag or version instead.  Alternatively, set the environment variable PLUGIN_RELEASE_MANAGEMENT_VERSION
-    default: latest
+    default: "2"
     type: string
 
 steps:


### PR DESCRIPTION
Pin plugin-release-management to v2 to avoid breaking current lerna monorepos using the orb, v3 will remove support for lerna:
https://github.com/salesforcecli/plugin-release-management/pull/507

@W-11526654@